### PR TITLE
metadata.json: Add Gnome 42 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Remove event list and clock/calendar app buttons from the calendar window. This is just an updated version of v2 by breiq",
   "name": "Minimalist Calendar 3",
-  "shell-version": ["3.36", "3.38", "40", "41"],
+  "shell-version": ["3.36", "3.38", "40", "41", "42"],
   "url": "https://github.com/mtharpe/gnome-minCal3-extension",
   "uuid": "miniCal3@mtharpe",
   "version": 3


### PR DESCRIPTION
This extension runs perfectly fine on Gnome 42.
I have tested this on Arch Linux and Linux 5.16.1.